### PR TITLE
[BUGFIX] Fix email setting on registration and profile edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - FEATURE     #34    support for sulu 1.3
  - FEATURE     #33    allow route name and add locale replacer in confirmation redirect 
  - BUGFIX      #31    fix completion listener listen on none safe methods.
  - ENHANCEMENT #29    translate country names with Symfony Intl.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - BUGFIX      #39    fixed get correct encoder for new salt
  - ENHANCEMENT ---    fixed the caching of completion redirect
  - FEATURE     #34    support for sulu 1.3
  - FEATURE     #33    allow route name and add locale replacer in confirmation redirect 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - ENHANCEMENT ---    fixed the caching of completion redirect
  - FEATURE     #34    support for sulu 1.3
  - FEATURE     #33    allow route name and add locale replacer in confirmation redirect 
  - BUGFIX      #31    fix completion listener listen on none safe methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - FEATURE     #33    allow route name and add locale replacer in confirmation redirect 
  - BUGFIX      #31    fix completion listener listen on none safe methods.
  - ENHANCEMENT #29    translate country names with Symfony Intl.
  - BUGFIX      #30    fix validation for subforms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev-develop
 
+ - BUGFIX      #31    fix completion listener listen on none safe methods.
  - ENHANCEMENT #29    translate country names with Symfony Intl.
  - BUGFIX      #30    fix validation for subforms.
  - BUGFIX      #26    remove contact when user is denied.

--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -85,11 +85,11 @@ abstract class AbstractController extends Controller
             $salt = $this->get('sulu_security.salt_generator')->getRandomSalt();
         }
 
+        $user->setSalt($salt);
         $encoder = $this->get('security.encoder_factory')->getEncoder($user);
         $password = $encoder->encodePassword($plainPassword, $salt);
 
         $user->setPassword($password);
-        $user->setSalt($salt);
 
         return $user;
     }

--- a/Controller/ConfirmationController.php
+++ b/Controller/ConfirmationController.php
@@ -33,6 +33,7 @@ class ConfirmationController extends AbstractController
     public function indexAction(Request $request, $token)
     {
         $communityManager = $this->getCommunityManager($this->getWebspaceKey());
+
         $success = false;
 
         // Confirm user by token
@@ -49,7 +50,13 @@ class ConfirmationController extends AbstractController
             $redirectTo = $communityManager->getConfigTypeProperty(self::TYPE, Configuration::REDIRECT_TO);
 
             if ($redirectTo) {
-                return $this->redirect($redirectTo);
+                if (strpos($redirectTo, '/') === 0) {
+                    $url = str_replace('{localization}', $request->getLocale(), $redirectTo);
+                } else {
+                    $url = $this->get('router')->generate($redirectTo);
+                }
+
+                return $this->redirect($url);
             }
 
             $success = true;

--- a/EventListener/CompletionListener.php
+++ b/EventListener/CompletionListener.php
@@ -114,6 +114,7 @@ class CompletionListener
 
             $response = new RedirectResponse($completionUrl);
             $response->setPrivate();
+            $response->setMaxAge(0);
             $event->setResponse($response);
         }
     }

--- a/EventListener/CompletionListener.php
+++ b/EventListener/CompletionListener.php
@@ -83,7 +83,7 @@ class CompletionListener
         $completionUrl = $this->router->generate('sulu_community.completion');
 
         if (!$event->isMasterRequest()
-            || $request->isMethod('post')
+            || !$request->isMethodSafe()
             || $request->isXmlHttpRequest()
             || $request->getPathInfo() === $completionUrl
             || $request->getPathInfo() === $this->fragmentPath

--- a/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/Tests/app/Resources/webspaces/sulu.io.xml
@@ -31,9 +31,6 @@
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <environments>
                 <environment type="prod">

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "require": {
         "php": "^5.5 || ^7.0",
-        "sulu/sulu": "dev-develop",
-        "sulu/document-manager": "@dev",
-        "massive/search-bundle": "@dev",
+        "sulu/sulu": "^1.3 || dev-develop",
         "beberlei/DoctrineExtensions": "^1.0"
     },
     "require-dev": {
+        "sulu/document-manager": "@dev",
+        "massive/search-bundle": "@dev",
         "zendframework/zend-stdlib": "2.3.1 as 2.0.0rc5",
         "zendframework/zendsearch": "2.*@dev",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #issuenum |
| Related issues/PRs | #issuenum |
| License | MIT |
| Documentation PR | sulu/sulu-docs#prnum |
#### What's in this PR?

Fixes of the setting of the users email address on the contact Email with respective emailType.
Additionally added necessary changes for profile changes of the users email address.
#### Why?

If a contact was edited in the Sulu backoffice, the mainEmail was deleted from the contact. That was because of a missing Email entity that needs to be created on registration and changed on email address changes through the users profile.
#### Example Usage

``` php
// If you added new features, show examples of how to use them here
// (remove this section if not a new feature)

$foo = new Foo();

// Now we can do
$foo->doSomething();
```
#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)
#### To Do
- [ ] Create a documentation PR
